### PR TITLE
Updated ac-api-controller to use ControllerBase class

### DIFF
--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -153,7 +153,7 @@
 			"namespace ${1}.Controllers",
 			"{",
 			"    [Route(\"api/[controller]\")]",
-			"    public class ${2:${TM_FILENAME_BASE/Controller//}}Controller : Controller",
+			"    public class ${2:${TM_FILENAME_BASE/Controller//}}Controller : ControllerBase",
 			"    {",
 			"        public ${2}Controller() { }",
 			"",


### PR DESCRIPTION
Hi, thanks for an awesome extension!

> Web API controller should derive from ControllerBase.

Reference [MS Docs](https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-2.2)